### PR TITLE
correct IP_COUNT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker service create \
   --secret=azure_ucp_admin.json \
   --log-driver json-file \
   --log-opt max-size=1m \
-  --env IPCOUNT=128 \
+  --env IP_COUNT=128 \
   --name ipallocator \
   docker4x/az-nic-ips:latest
 ```


### PR DESCRIPTION
Should be IP_COUNT not IPCOUNT per https://github.com/ddebroy/az-nic-ips/blob/master/src/azip/main.go

Default of 20 from init.sh is always used otherwise